### PR TITLE
fix for new "Borderless" mode

### DIFF
--- a/libraries/imgui-hook/imgui-hook.cpp
+++ b/libraries/imgui-hook/imgui-hook.cpp
@@ -129,11 +129,11 @@ LRESULT CALLBACK wndProc_H(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
     return CallWindowProc(wndProc, hwnd, msg, wParam, lParam);
 }
 
-void (__thiscall* CCEGLView_toggleFullScreen)(void*, bool);
-void __fastcall CCEGLView_toggleFullScreen_H(void* self, void*, bool toggle)
+void (__thiscall* CCEGLView_toggleFullScreen)(void*, bool, bool);
+void __fastcall CCEGLView_toggleFullScreen_H(void* self, void*, bool fullscreen, bool borderless)
 {
     ImGuiHook::Unload();
-    CCEGLView_toggleFullScreen(self, toggle);
+    CCEGLView_toggleFullScreen(self, fullscreen, borderless);
 }
 
 void ImGuiHook::Load(std::function<void(void*, void*, void**)> hookFunc)
@@ -145,7 +145,7 @@ void ImGuiHook::Load(std::function<void(void*, void*, void**)> hookFunc)
     );
 
     hookFunc(
-        GetProcAddress(GetModuleHandleA("libcocos2d.dll"), "?toggleFullScreen@CCEGLView@cocos2d@@QAEX_N@Z"),
+        GetProcAddress(GetModuleHandleA("libcocos2d.dll"), "?toggleFullScreen@CCEGLView@cocos2d@@QAEX_N0@Z"),
         CCEGLView_toggleFullScreen_H,
         reinterpret_cast<void**>(&CCEGLView_toggleFullScreen)
     );

--- a/source/memory.cpp
+++ b/source/memory.cpp
@@ -20,7 +20,7 @@ uintptr_t memory::PatternScan(uintptr_t base, uintptr_t scanSize, const std::str
         else {
             std::string byteStr = signature.substr(i, 2);
             patternData.push_back({ false, static_cast<uint8_t>(std::stoul(byteStr, nullptr, 16)) });
-            i += 2;
+            i++;
         }
     }
 


### PR DESCRIPTION
`CCEGLView::toggleFullScreen` now takes borderless as second boolean.
Fixes menu not opening after switching either option in settings.