### PR TITLE
Fix typo in replay engine

### DIFF
--- a/source/replayEngine.cpp
+++ b/source/replayEngine.cpp
@@ -8,7 +8,7 @@ std::string ReplayEngine::save(char *name) {
     auto isEmpty = [](char *str) {return (str != nullptr && str[0] == '\0');};
     if (replay.empty())
     {
-        return "Replay doens't have actions";
+        return "Replay doesn't have actions";
     }
     else
     {


### PR DESCRIPTION
Fixed typo: "Replay doens't have actions" → "Replay doesn't have actions"